### PR TITLE
Remove leading wildcards for `contains` and `endswith` conditions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pySigma-backend-carbonblack"
-version = "0.1.5"
+version = "0.1.6"
 description = "pySigma carbonblack backend"
 authors = ["Cori Smith <cs2718281@gmail.com>"]
 license = "MIT"

--- a/sigma/backends/carbonblack/carbonblack.py
+++ b/sigma/backends/carbonblack/carbonblack.py
@@ -70,7 +70,8 @@ class CarbonBlackBackend(TextQueryBackend):
     unbound_value_re_expression : ClassVar[str] = '{value}'   # Expression for regular expression not bound to a field as format string with placeholder {value} and {flag_x} as described for re_expression
 
     def convert_value_str(self, s : SigmaString, state : ConversionState) -> str:
-        """Convert a SigmaString into a plain string which can be used in query."""
+        """Convert a SigmaString into a plain string which can be used in query.
+        In carbonBlack, leading wildcards are implied and not allowed to be explicitly added in the query"""
         converted = s.convert(
             self.escape_char,
             self.wildcard_multi,
@@ -78,6 +79,9 @@ class CarbonBlackBackend(TextQueryBackend):
             self.str_quote + self.add_escaped,
             self.filter_chars,
         )
+        if converted.startswith(self.wildcard_multi) or converted.startswith(self.wildcard_single):
+            converted = converted[1:]
+
         if self.decide_string_quoting(s):
             return self.quote_string(converted)
         else:

--- a/tests/test_backend_carbonblack.py
+++ b/tests/test_backend_carbonblack.py
@@ -95,7 +95,8 @@ def test_carbonblack_not_expression(carbonblack_backend : CarbonBlackBackend):
 
 def test_carbonblack_contains_expression(carbonblack_backend : CarbonBlackBackend):
     assert carbonblack_backend.convert(
-        SigmaCollection.from_yaml("""title: Test
+        SigmaCollection.from_yaml("""
+            title: Test
             status: test
             logsource:
                 category: process_creation
@@ -109,7 +110,8 @@ def test_carbonblack_contains_expression(carbonblack_backend : CarbonBlackBacken
 
 def test_carbonblack_startswith_expression(carbonblack_backend : CarbonBlackBackend):
     assert carbonblack_backend.convert(
-        SigmaCollection.from_yaml("""title: Test
+        SigmaCollection.from_yaml("""
+            title: Test
             status: test
             logsource:
                 category: process_creation
@@ -123,7 +125,8 @@ def test_carbonblack_startswith_expression(carbonblack_backend : CarbonBlackBack
 
 def test_carbonblack_endswith_expression(carbonblack_backend : CarbonBlackBackend):
     assert carbonblack_backend.convert(
-        SigmaCollection.from_yaml("""title: Test
+        SigmaCollection.from_yaml("""
+            title: Test
             status: test
             logsource:
                 category: process_creation

--- a/tests/test_backend_carbonblack.py
+++ b/tests/test_backend_carbonblack.py
@@ -93,6 +93,47 @@ def test_carbonblack_not_expression(carbonblack_backend : CarbonBlackBackend):
         """)
     ) == ['-fieldA:valueA']
 
+def test_carbonblack_contains_expression(carbonblack_backend : CarbonBlackBackend):
+    assert carbonblack_backend.convert(
+        SigmaCollection.from_yaml("""title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    fieldA|contains: valueA
+                condition: sel
+        """)
+    ) == ['fieldA:valueA*']
+
+def test_carbonblack_startswith_expression(carbonblack_backend : CarbonBlackBackend):
+    assert carbonblack_backend.convert(
+        SigmaCollection.from_yaml("""title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    fieldA|startswith: valueA
+                condition: sel
+        """)
+    ) == ['fieldA:valueA*']
+
+def test_carbonblack_endswith_expression(carbonblack_backend : CarbonBlackBackend):
+    assert carbonblack_backend.convert(
+        SigmaCollection.from_yaml("""title: Test
+            status: test
+            logsource:
+                category: process_creation
+                product: test_product
+            detection:
+                sel:
+                    fieldA|endswith: valueA
+                condition: sel
+        """)
+    ) == ['fieldA:valueA']
 
 def test_carbonblack_in_expression(carbonblack_backend : CarbonBlackBackend):
     assert carbonblack_backend.convert(


### PR DESCRIPTION
Changes
- Remove leading wildcard for `contains` and `endswith` conditions

Closes #9 