### PR TITLE
Update carbonblack.py

### DIFF
--- a/sigma/pipelines/carbonblack/carbonblack.py
+++ b/sigma/pipelines/carbonblack/carbonblack.py
@@ -178,7 +178,8 @@ def CarbonBlack_pipeline() -> ProcessingPipeline:
         LogsourceCondition(category="registry_event"),
         LogsourceCondition(category="registry_set"),
         LogsourceCondition(category="network_connection"),
-        LogsourceCondition(category="firewall")
+        LogsourceCondition(category="firewall"),
+        LogsourceCondition(category="image_load")
     ]
 
     general_supported_fields = ['md5','sha256']


### PR DESCRIPTION
Adds LogsourceCondition(category="image_load") to supported_categories in the CarbonBlack pipeline so that the existing "ImageLoaded" → "modload_name" mapping applies.